### PR TITLE
Packaging fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
-debian
-!debian/*install
-!debian/not-installed
-!debian/triggers
-!debian/control
-!debian/rules
-!debian/changelog
-!debian/source
+debian/tmp
+debian/.debhelper
+debian/debhelper-build-stamp
+debian/files
+debian/julia.substvars
+debian/julia
 upstream
 julia-*

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends:
 Package: julia
 Architecture: amd64 arm64
 Breaks: julia-common (<< 0.5.0~)
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, p7zip-full
 Recommends: git, openssl
 Description: high-performance programming language for technical computing
  Julia is a high-level, high-performance dynamic programming language for

--- a/debian/julia.install
+++ b/debian/julia.install
@@ -12,3 +12,5 @@
 /usr/share/julia/test
 /usr/include/julia
 /usr/lib/libjulia.so
+/usr/share/licenses/julia
+/usr/share/julia/cert.pem

--- a/debian/not-installed
+++ b/debian/not-installed
@@ -1,2 +1,0 @@
-usr/share/doc/julia/html/*
-usr/share/icons/hicolor/icon-theme.cache

--- a/justfile
+++ b/justfile
@@ -14,4 +14,6 @@ distclean:
 
 install:
   mkdir -p {{rootdir}}/usr
+  mkdir -p {{rootdir}}/usr/share/licenses/julia
   cp ./{{target}}/* {{rootdir}}/usr -r
+  install -Dm644 ./{{target}}/LICENSE.md {{rootdir}}/usr/share/licenses/julia/LICENSE.md


### PR DESCRIPTION
1. Adds a dependency so the julia package manager can unzip
packages. Otherwise installing any package on a fresh install of
Pop!_OS would fail.
    
2. Install the LICENSE.md file
    
3. Include `/usr/share/julia/cert.pem` when installing. Not
including this file caused some Julia packages to be unable to
install, particularly `HTTP`, and anything that depended on it, for
example `Pluto`

> Please make sure that packaging works on both ARM and x86